### PR TITLE
Ignore variables with causality local/internal

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -92,14 +92,15 @@ func ReadModelDescription(fmuPath string) (fmu structs.FMU) {
 
 			var variables []structs.Variable
 			variables = make([]structs.Variable, nVar)
-			for i := 0; i < nVar; i++ {
-				scalarVariable := modelDescription.ModelVariables.ScalarVariables[i]
-				variables[i] = structs.Variable{
-					Name:           scalarVariable.Name,
-					ValueReference: scalarVariable.ValueReference,
-					Causality:      scalarVariable.Causality,
-					Variability:    scalarVariable.Variability,
-					Type:           getValueType(scalarVariable),
+			for _, scalarVariable := range modelDescription.ModelVariables.ScalarVariables {
+				if includeVariable(scalarVariable) {
+					variables = append(variables, structs.Variable{
+						Name:           scalarVariable.Name,
+						ValueReference: scalarVariable.ValueReference,
+						Causality:      scalarVariable.Causality,
+						Variability:    scalarVariable.Variability,
+						Type:           getValueType(scalarVariable),
+					})
 				}
 			}
 			fmu.Variables = variables
@@ -108,4 +109,7 @@ func ReadModelDescription(fmuPath string) (fmu structs.FMU) {
 		}
 	}
 	return
+}
+func includeVariable(variable ScalarVariable) bool {
+	return variable.Causality != "local" && variable.Causality != "internal"
 }


### PR DESCRIPTION
This covers issue #36. 

TLDR: For a couple of the demo setups it was discovered that the client/server bogs down due to fetching too many variable values when browsing a slave's variables. A temporary ailment is not asking for the values of variables with causality local (FMI 2.0) or internal (FMI 1.0), of which there are **many**. 

A better solution should be implemented in the future.