### PR TITLE
Provide trend data for multiple variables

### DIFF
--- a/cse/cse.go
+++ b/cse/cse.go
@@ -8,7 +8,6 @@ import (
 	"cse-server-go/metadata"
 	"cse-server-go/structs"
 	"fmt"
-	"github.com/shirou/gopsutil/mem"
 	"io/ioutil"
 	"log"
 	"math"
@@ -424,7 +423,6 @@ func GetSignalValue(module string, cardinality string, signal string) int {
 func SimulationStatus(simulationStatus *structs.SimulationStatus, sim *Simulation) structs.JsonResponse {
 	simulationStatus.Mutex.Lock()
 	defer simulationStatus.Mutex.Unlock()
-	virtualMemoryStats, _ := mem.VirtualMemory()
 	if simulationStatus.Loaded {
 		execStatus := getExecutionStatus(sim.Execution)
 		return structs.JsonResponse{
@@ -437,7 +435,6 @@ func SimulationStatus(simulationStatus *structs.SimulationStatus, sim *Simulatio
 			Status:               simulationStatus.Status,
 			ConfigDir:            simulationStatus.ConfigDir,
 			TrendSignals:         simulationStatus.TrendSignals,
-			Memory:               virtualMemoryStats,
 		}
 	} else {
 		return structs.JsonResponse{

--- a/structs/structs.go
+++ b/structs/structs.go
@@ -1,7 +1,6 @@
 package structs
 
 import (
-	"github.com/shirou/gopsutil/mem"
 	"sync"
 )
 
@@ -18,15 +17,14 @@ type Module struct {
 }
 
 type JsonResponse struct {
-	Loaded               bool     `json:"loaded"`
-	SimulationTime       float64  `json:"time"`
-	RealTimeFactor       float64  `json:"realTimeFactor"`
-	IsRealTimeSimulation bool     `json:"isRealTime"`
-	ConfigDir            string   `json:"configDir,omitempty"`
-	Status               string   `json:"status,omitempty"`
-	Modules              []string `json:"modules"`
-	Module               Module   `json:"module,omitempty"`
-	Memory               *mem.VirtualMemoryStat
+	Loaded               bool          `json:"loaded"`
+	SimulationTime       float64       `json:"time"`
+	RealTimeFactor       float64       `json:"realTimeFactor"`
+	IsRealTimeSimulation bool          `json:"isRealTime"`
+	ConfigDir            string        `json:"configDir,omitempty"`
+	Status               string        `json:"status,omitempty"`
+	Modules              []string      `json:"modules"`
+	Module               Module        `json:"module,omitempty"`
 	TrendSignals         []TrendSignal `json:"trend-values"`
 }
 


### PR DESCRIPTION
This solves #43, providing trend data for multiple variables. 

I also discovered a race condition where three loops were accessing the SimulationStatus struct at the same time, causing a crash when removing all trend variables and simultaneously extracting trend values. Seems to be fixed by adding a mutex-ish lock to the SimulationStatus struct.

Also removed the unused memory info from the JsonResponse struct.

This is linked to cse-client [PR #24](https://github.com/open-simulation-platform/cse-client/pull/24)