### PR TITLE
Make a default handler for '/' serving index.html and /static/*

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,6 +96,9 @@ pipeline {
                             dir('src/cse-server-go/dist') {
                                 deleteDir();
                             }
+                            dir('src/cse-server-go/resources/public') {
+                                deleteDir();
+                            }
                         }
                     }
                 }
@@ -178,6 +181,9 @@ pipeline {
                     post {
                         cleanup {
                             dir('src/cse-server-go/dist') {
+                                deleteDir();
+                            }
+                            dir('src/cse-server-go/resources/public') {
                                 deleteDir();
                             }
                         }

--- a/server/server.go
+++ b/server/server.go
@@ -15,9 +15,6 @@ func Server(command chan []string, state chan structs.JsonResponse, simulationSt
 	router := mux.NewRouter()
 	box := packr.NewBox("../resources/public")
 
-	router.Handle("/", http.FileServer(box))
-	router.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(box)))
-
 	router.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(cse.GenerateJsonResponse(simulationStatus, sim, structs.CommandFeedback{}))
@@ -41,10 +38,13 @@ func Server(command chan []string, state chan structs.JsonResponse, simulationSt
 		body, _ := ioutil.ReadAll(r.Body)
 		commandRequest := []string{}
 		json.Unmarshal(body, &commandRequest)
-	command <- commandRequest
+		command <- commandRequest
 	}).Methods("PUT")
 
 	router.HandleFunc("/ws", WebsocketHandler(command, state))
+
+	//Default handler
+	router.PathPrefix("/").Handler(http.FileServer(box))
 
 	log.Fatal(http.ListenAndServe(":8000", router))
 }


### PR DESCRIPTION
This fixex #59. The default handler now catch / and anything beneath that is not previously configured. It serves index.html and static content under /static/*

Also make sure to cleanup ``resources/public`` to make sure no files remains to next build.
