### PR TITLE
feature(scripts): add run scripts for windows and linux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
                         CONAN_USER_HOME_SHORT = "${env.CONAN_USER_HOME}"
                         OSP_CONAN_CREDS = credentials('jenkins-osp-conan-creds')
                     }
-                    
+
                     tools {
                         go 'go-1.11.5'
                         //'com.cloudbees.jenkins.plugins.customtools.CustomTool' 'mingw-w64' awaiting fix in customToolsPlugin
@@ -35,7 +35,7 @@ pipeline {
                                     projectName: 'open-simulation-platform/cse-client/master',
                                     filter: 'resources/public/**/*',
                                     target: 'src/cse-server-go')
-                                
+
                                 dir ('src/cse-server-go') {
                                     sh 'conan remote add osp https://osp-conan.azurewebsites.net/artifactory/api/conan/conan-local --force'
                                     sh 'conan user -p $OSP_CONAN_CREDS_PSW -r osp $OSP_CONAN_CREDS_USR'
@@ -56,6 +56,9 @@ pipeline {
                             steps {
                                 dir ('src/cse-server-go/dist/bin') {
                                     sh 'cp -rf ../../cse-server-go.exe .'
+                                }
+                                dir ('src/cse-server-go/dist') {
+                                    sh 'cp -rf ../run-windows.cmd .'
                                 }
                             }
                         }
@@ -120,12 +123,11 @@ pipeline {
                                     projectName: 'open-simulation-platform/cse-client/master',
                                     filter: 'resources/public/**/*',
                                     target: 'src/cse-server-go')
-                                
+
                                 dir ('src/cse-server-go') {
                                     sh 'conan remote add osp https://osp-conan.azurewebsites.net/artifactory/api/conan/conan-local --force'
                                     sh 'conan user -p $OSP_CONAN_CREDS_PSW -r osp $OSP_CONAN_CREDS_USR'
                                     sh 'conan install . -s build_type=Release -s compiler.libcxx=libstdc++11 -u'
-                                    sh 'patchelf --set-rpath \'$ORIGIN/../lib\' dist/lib/*'
                                 }
                             }
                         }
@@ -141,6 +143,13 @@ pipeline {
                             steps {
                                 dir ('src/cse-server-go/dist/bin') {
                                     sh 'cp -rf ../../cse-server-go .'
+                                }
+                                dir ('src/cse-server-go/dist') {
+                                    sh 'cp ../run-linux .'
+                                }
+                                dir ('src/cse-server-go') {
+                                    sh 'chmod 755 set-rpath'
+                                    sh './set-rpath dist/lib'
                                 }
                             }
                         }

--- a/run-linux
+++ b/run-linux
@@ -1,0 +1,3 @@
+#!/bin/bash
+xdg-open http://localhost:8000
+./bin/cse-server-go

--- a/run-windows.cmd
+++ b/run-windows.cmd
@@ -1,0 +1,4 @@
+@echo off
+start .\bin\cse-server-go.exe
+timeout 2 > nul
+start http://localhost:8000

--- a/set-rpath
+++ b/set-rpath
@@ -1,0 +1,5 @@
+#!/bin/sh
+for file in $(pwd)/$1/*
+do
+  patchelf --set-rpath '$ORIGIN' $file
+done


### PR DESCRIPTION
Add scripts run-windows.cmd and run-linux to repository. The scripts execute cse-server-go and opens the default browser on localhost:8000.
Update Jenkinsfile to copy these scripts into the distribution folder.
Fix Linux library linking by creating a script to update the rpath of all files in /lib during Jenkins build process.

Closes #64