### PR TITLE
Support operations on boolean and string variables

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
 
     triggers {
         upstream(
-            upstreamProjects: 'open-simulation-platform/cse-core/feature%2F253-observe-bool-and-string-variables, open-simulation-platform/cse-client/feature%2F87-bools-and-strings',
+            upstreamProjects: 'open-simulation-platform/cse-core/master, open-simulation-platform/cse-client/master',
             threshold: hudson.model.Result.SUCCESS)
     }
 
@@ -32,7 +32,7 @@ pipeline {
                         stage ('Get dependencies') {
                             steps {
                                 copyArtifacts(
-                                    projectName: 'open-simulation-platform/cse-client/feature%2F87-bools-and-strings',
+                                    projectName: 'open-simulation-platform/cse-client/master',
                                     filter: 'resources/public/**/*',
                                     target: 'src/cse-server-go')
 
@@ -120,7 +120,7 @@ pipeline {
                         stage ('Get dependencies') {
                             steps {
                                 copyArtifacts(
-                                    projectName: 'open-simulation-platform/cse-client/feature%2F87-bools-and-strings',
+                                    projectName: 'open-simulation-platform/cse-client/master',
                                     filter: 'resources/public/**/*',
                                     target: 'src/cse-server-go')
 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,7 +1,7 @@
 [generators]
 
 [requires]
-cse-core/0.3.0@osp/feature_253-observe-bool-and-string-variables
+cse-core/0.3.0@osp/master
 
 [imports]
 include, cse.h                  -> ./include


### PR DESCRIPTION
This fixes #80, adding support for getting, overriding and resetting values for boolean and string type variables.

Should not be merged before cse-core PR [#257](https://github.com/open-simulation-platform/cse-core/pull/257) and cse-client PR [#88](https://github.com/open-simulation-platform/cse-client/pull/88).