### PR TITLE
Switch to using msgpack binary format instead of json

### DIFF
--- a/cse/observers.go
+++ b/cse/observers.go
@@ -9,7 +9,6 @@ import "C"
 import (
 	"cse-server-go/structs"
 	"errors"
-	"math"
 )
 
 func createObserver() (observer *C.cse_observer) {
@@ -40,18 +39,6 @@ func observerDestroy(observer *C.cse_observer) {
 	C.cse_observer_destroy(observer)
 }
 
-func uglyNanFix(value C.double) interface{} {
-	floatValue := float64(value)
-	if math.IsNaN(floatValue) {
-		return "NaN"
-	} else if math.IsInf(floatValue, 1) {
-		return "+Inf"
-	} else if math.IsInf(floatValue, -1) {
-		return "-Inf"
-	}
-	return floatValue
-}
-
 func observerGetReals(observer *C.cse_observer, variables []structs.Variable, slaveIndex int) (realSignals []structs.Signal) {
 	var realValueRefs []C.cse_variable_index
 	var realVariables []structs.Variable
@@ -75,7 +62,7 @@ func observerGetReals(observer *C.cse_observer, variables []structs.Variable, sl
 				Name:      realVariables[k].Name,
 				Causality: realVariables[k].Causality,
 				Type:      realVariables[k].Type,
-				Value:     uglyNanFix(realOutVal[k]),
+				Value:     realOutVal[k],
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ require (
 	github.com/gobuffalo/packr v1.22.0
 	github.com/gorilla/mux v1.7.0
 	github.com/gorilla/websocket v1.4.0
-	golang.org/x/net v0.0.0-20190213061140-3a22650c66bd
+	github.com/ugorji/go/codec v1.1.7
 )

--- a/go.sum
+++ b/go.sum
@@ -315,7 +315,11 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
+github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
+github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
+github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/unrolled/secure v0.0.0-20180918153822-f340ee86eb8b/go.mod h1:mnPT77IAdsi/kV7+Es7y+pXALeV3h7G6dQF6mNYjcLA=
 github.com/unrolled/secure v0.0.0-20181005190816-ff9db2ff917f/go.mod h1:mnPT77IAdsi/kV7+Es7y+pXALeV3h7G6dQF6mNYjcLA=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
@@ -348,8 +352,6 @@ golang.org/x/net v0.0.0-20181106065722-10aee1819953/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181207154023-610586996380/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20190213061140-3a22650c66bd h1:HuTn7WObtcDo9uEEU7rEqL0jYthdXAmZ6PP+meazmaU=
-golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=

--- a/server/websockets.go
+++ b/server/websockets.go
@@ -2,23 +2,27 @@ package server
 
 import (
 	"cse-server-go/structs"
-	"encoding/json"
 	"github.com/gorilla/websocket"
+	"github.com/ugorji/go/codec"
 	"io"
 	"log"
 	"net/http"
+	"reflect"
 )
 
 type JsonRequest struct {
 	Command     []string `json:"command,omitempty"`
-	Module      string   `json:"module,omitempty"`
-	Modules     bool     `json:"modules,omitempty"`
-	Connections bool     `json:"connections,omitempty"`
 }
 
 var upgrader = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true },}
 
 func commandLoop(command chan []string, conn *websocket.Conn) {
+	var (
+		mh codec.MsgpackHandle
+	)
+	mh.MapType = reflect.TypeOf(map[string]interface{}(nil))
+	decoder := codec.NewDecoder(nil, &mh)
+
 	for {
 		data := JsonRequest{}
 		_, r, err := conn.NextReader()
@@ -26,7 +30,10 @@ func commandLoop(command chan []string, conn *websocket.Conn) {
 			log.Println("read error:", err)
 			break
 		}
-		err = json.NewDecoder(r).Decode(&data)
+
+		decoder.Reset(r)
+		err = decoder.Decode(&data)
+
 		if err == io.EOF {
 			// One value is expected in the message.
 			log.Println("Message was EOF:", err, data)
@@ -40,11 +47,19 @@ func commandLoop(command chan []string, conn *websocket.Conn) {
 }
 
 func stateLoop(state chan structs.JsonResponse, conn *websocket.Conn) {
+	var (
+		mh codec.MsgpackHandle
+	)
+	mh.MapType = reflect.TypeOf(map[string]interface{}(nil))
+	encoder := codec.NewEncoder(nil, &mh)
 	for {
 		latestState := <-state
-		err := conn.WriteJSON(latestState)
+
+		w, err := conn.NextWriter(2)
+		encoder.Reset(w)
+		err = encoder.Encode(latestState)
 		if err != nil {
-			log.Println("write:", err)
+			log.Println("write error:", err)
 			log.Println("latestState:", latestState)
 			break
 		}


### PR DESCRIPTION
This fixes #20, double NaN and Inf not supported by the JSON format. 

This PR switches to using the MessagePack binary format instead of JSON. The library prefers the tag `codec` in structs but falls back to `json`, so not many changes were necessary.

Note: A workaround for NaN and Inf values was already implemented with `uglyNanFix()`, but this was only implemented for `observerGetReals(), and not the time series functions.

Test together with cse-client branch of the same name.