### PR TITLE
Rename variable index

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
 
     triggers {
         upstream(
-            upstreamProjects: 'open-simulation-platform/cse-core/rename-variable-index, open-simulation-platform/cse-client/master',
+            upstreamProjects: 'open-simulation-platform/cse-core/master, open-simulation-platform/cse-client/master',
             threshold: hudson.model.Result.SUCCESS)
     }
 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,7 +1,7 @@
 [generators]
 
 [requires]
-cse-core/0.5.0@osp/rename-variable-index
+cse-core/0.5.0@osp/master
 
 [options]
 cse-core:fmuproxy=True


### PR DESCRIPTION
Closes #103, renaming `variable_index` to `value_reference`.