### PR TITLE
Send loading status while loading simulation.

### DIFF
--- a/cse/cse.go
+++ b/cse/cse.go
@@ -587,6 +587,7 @@ func executeCommand(cmd []string, sim *Simulation, status *structs.SimulationSta
 	var message = "No feedback implemented for this command"
 	switch cmd[0] {
 	case "load":
+		status.Loading = true
 		var configDir string
 		success, message, configDir = initializeSimulation(sim, cmd[1], cmd[2])
 		if success {
@@ -597,6 +598,7 @@ func executeCommand(cmd []string, sim *Simulation, status *structs.SimulationSta
 			scenarios := findScenarios(status)
 			shorty.Scenarios = &scenarios
 		}
+		status.Loading = false
 	case "teardown":
 		status.Loaded = false
 		status.Status = "stopped"
@@ -749,6 +751,7 @@ func GetSignalValue(module string, cardinality string, signal string) int {
 
 func GenerateJsonResponse(status *structs.SimulationStatus, sim *Simulation, feedback structs.CommandFeedback, shorty structs.ShortLivedData) structs.JsonResponse {
 	var response = structs.JsonResponse{
+		Loading: status.Loading,
 		Loaded: status.Loaded,
 		Status: status.Status,
 	}
@@ -794,7 +797,7 @@ func StateUpdateLoop(state chan structs.JsonResponse, simulationStatus *structs.
 func addFmu(execution *C.cse_execution, fmuPath string) (*C.cse_slave, error) {
 	baseName := filepath.Base(fmuPath)
 	instanceName := strings.TrimSuffix(baseName, filepath.Ext(baseName))
-	fmt.Printf("Creating instance %s from %s", instanceName, fmuPath)
+	fmt.Printf("Creating instance %s from %s\n", instanceName, fmuPath)
 	localSlave := createLocalSlave(fmuPath, instanceName)
 	if localSlave == nil {
 		printLastError()

--- a/structs/structs.go
+++ b/structs/structs.go
@@ -19,6 +19,7 @@ type ManipulatedVariable struct {
 }
 
 type JsonResponse struct {
+	Loading              bool                  `json:"loading"`
 	Loaded               bool                  `json:"loaded"`
 	SimulationTime       float64               `json:"time"`
 	RealTimeFactor       float64               `json:"realTimeFactor"`
@@ -69,6 +70,7 @@ type ShortLivedData struct {
 }
 
 type SimulationStatus struct {
+	Loading             bool
 	Loaded              bool
 	ConfigDir           string
 	Module              string


### PR DESCRIPTION
Closes #116, reporting to the client that a simulation is being loaded.

For testing, use together with cse-client branch `feature/104-indicate-loading-status`.