### PR TITLE
Don't use comma-separated string for variable encoding

### DIFF
--- a/cse/cse.go
+++ b/cse/cse.go
@@ -744,23 +744,24 @@ func setSignalSubscriptions(status *structs.SimulationStatus, cmd []string) (boo
 	var success = true
 	if len(cmd) > 1 {
 		status.Module = cmd[1]
-		for i, signal := range cmd {
-			if i > 1 {
-				parts := strings.Split(signal, ",")
-				valRef, err := strconv.Atoi(parts[3])
-				if err != nil {
-					message = strCat("Could not parse value reference from: ", signal, ", ", err.Error())
-					log.Println(message)
-					success = false
-				} else {
-					variables = append(variables,
-						structs.Variable{
-							Name:           parts[0],
-							Causality:      parts[1],
-							Type:           parts[2],
-							ValueReference: valRef,
-						})
-				}
+		for j := 2; j < (len(cmd) - 3); j += 4 {
+			name := cmd[j]
+			caus := cmd[j+1]
+			typ := cmd[j+2]
+			vr := cmd[j+3]
+			valRef, err := strconv.Atoi(vr)
+			if err != nil {
+				message = strCat("Could not parse value reference from: ", vr, ", ", err.Error())
+				log.Println(message)
+				success = false
+			} else {
+				variables = append(variables,
+					structs.Variable{
+						Name:           name,
+						Causality:      caus,
+						Type:           typ,
+						ValueReference: valRef,
+					})
 			}
 		}
 	} else {


### PR DESCRIPTION
Closes #119.

This changes the variable encoding format for specifying variable value subscriptions from:
```
["signals","model-name","name,causality,type,value-ref","name,causality,type,value-ref", ... ]
```
to
```
["signals","model-name","name","causality","type","value-ref","name","causality","type","value-ref", ... ]
```
This means we don't rely on special characters to separate variable properties. The FMI standard is pretty liberal on variable naming, so this feels like the most robust option I could think of.

Strongly coupled with cse-client branch `safe-variable-encoding`.