### PR TITLE
Display libcosim version in the client

### DIFF
--- a/libcosim/libcosim.go
+++ b/libcosim/libcosim.go
@@ -831,10 +831,10 @@ func GetSignalValue(module string, cardinality string, signal string) int {
 
 func GenerateJsonResponse(status *structs.SimulationStatus, sim *Simulation, feedback structs.CommandFeedback, shorty structs.ShortLivedData) structs.JsonResponse {
 	var response = structs.JsonResponse{
-		Loading:         status.Loading,
-		Loaded:          status.Loaded,
-		Status:          status.Status,
-		LibcosimVersion: status.LibcosimVersion,
+		Loading:    status.Loading,
+		Loaded:     status.Loaded,
+		Status:     status.Status,
+		LibVersion: status.LibVersion,
 	}
 
 	if status.Loaded {
@@ -984,16 +984,11 @@ func SetupLogging() {
 	}
 }
 
-type Versions struct {
-	LibVer  string `json:"libcosim"`
-	LibcVer string `json:"libcosimc"`
-}
-
-func Version() Versions {
+func Version() structs.Versions {
 	libVer := C.cosim_libcosim_version()
 	libcVer := C.cosim_libcosimc_version()
 
-	return Versions{
+	return structs.Versions{
 		LibVer:  fmt.Sprintf("%d.%d.%d", int(libVer.major), int(libVer.minor), int(libVer.patch)),
 		LibcVer: fmt.Sprintf("%d.%d.%d", int(libcVer.major), int(libcVer.minor), int(libcVer.patch)),
 	}

--- a/main.go
+++ b/main.go
@@ -19,10 +19,10 @@ func main() {
 	state := make(chan structs.JsonResponse, 10)
 
 	simulationStatus := structs.SimulationStatus{
-		Loaded:          false,
-		Status:          "stopped",
-		Trends:          []structs.Trend{},
-		LibcosimVersion: libcosim.Version().LibcVer,
+		Loaded:     false,
+		Status:     "stopped",
+		Trends:     []structs.Trend{},
+		LibVersion: libcosim.Version(),
 	}
 
 	// Passing the channel to the go routine

--- a/src/client/core.cljs
+++ b/src/client/core.cljs
@@ -241,8 +241,8 @@
 
 (rf/reg-sub :plot-config-changed? #(:plot-config-changed? %))
 
-(rf/reg-sub :libcosimc-version (fn [db]
-                                 (-> db :state :libcosimVersion)))
+(rf/reg-sub :lib-version (fn [db]
+                                 (-> db :state :libVersion)))
 
 (k/start! {:routes         routes
            :hash-routing?  true

--- a/src/client/view.cljs
+++ b/src/client/view.cljs
@@ -337,7 +337,7 @@
         scenario-name      (rf/subscribe [:scenario-id])
         error              (rf/subscribe [:error])
         error-dismissed    (rf/subscribe [:error-dismissed])
-        libcosim-version   (rf/subscribe [:libcosimc-version])]
+        lib-version         (rf/subscribe [:lib-version])]
     (fn []
       [:div
        [:div.ui.inverted.huge.borderless.fixed.menu
@@ -367,8 +367,10 @@
            [:a.item {:on-click #(rf/dispatch [::controller/toggle-show-success-feedback-messages])}
             (if @(rf/subscribe [:show-success-feedback-messages]) [:i.toggle.on.icon.green] [:i.toggle.off.icon])
             "Show success command feedback"]
-           (when @libcosim-version
-             [:span.item [:i.icon.info.circle] (str "libcosim version: " @libcosim-version)])]]]]
+           (when (:libcosim @lib-version)
+             [:span.item [:i.icon.info.circle] (str "LibCosim version: " (:libcosim @lib-version))])
+           (when (:libcosimc @lib-version)
+             [:span.item [:i.icon.info.circle] (str "LibCosimC version: " (:libcosimc @lib-version))])]]]]
        [:div.ui.grid
         [:div.row
          [:div#sidebar.column

--- a/structs/structs.go
+++ b/structs/structs.go
@@ -33,7 +33,7 @@ type JsonResponse struct {
 	RealTimeFactorTarget float64               `json:"realTimeFactorTarget"`
 	IsRealTimeSimulation bool                  `json:"isRealTime"`
 	ConfigDir            string                `json:"configDir,omitempty"`
-	LibcosimVersion      string                `json:"libcosimVersion,omitempty"`
+	LibVersion           Versions              `json:"libVersion,omitempty"`
 	Status               string                `json:"status,omitempty"`
 	Module               Module                `json:"module,omitempty"`
 	Trends               []Trend               `json:"trends"`
@@ -81,7 +81,7 @@ type SimulationStatus struct {
 	Loading             bool
 	Loaded              bool
 	ConfigDir           string
-	LibcosimVersion     string
+	LibVersion          Versions
 	Module              string
 	SignalSubscriptions []Variable
 	Trends              []Trend
@@ -127,4 +127,9 @@ type Plot struct {
 
 type PlotConfig struct {
 	Plots []Plot `json:"plots"`
+}
+
+type Versions struct {
+	LibVer  string `json:"libcosim"`
+	LibcVer string `json:"libcosimc"`
 }


### PR DESCRIPTION
Added functionality to display under the menu "?", the current version of libcosim. Post only once to the endpoint /version and store in app-db.

Closes #147 