### PR TITLE
bugfix: trend crashes on open for production build

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -41,7 +41,7 @@
                        {:id           "min"
                         :source-paths ["src"]
                         :compiler     {:output-to      "resources/public/static/js/compiled/app.js"
-                                       :optimizations  :advanced
+                                       :optimizations  :simple
                                        :parallel-build true
                                        :foreign-libs   [{:file     "resources/public/static/js/plotly.min.js"
                                                          :provides ["cljsjs.plotly"]}]}}]}


### PR DESCRIPTION
When compiling the client code with advanced optimization the trend would crash on open. This was due to the external
Plotly library, and specifically an update to a newer version than what was available from
cljsjs (https://github.com/open-simulation-platform/cse-client/pull/134).

The problem is fixed by setting optimizations to "simple", which still does whitespace and comment removal and local
variable renaming, but not dead code elimination and global var and function name
renaming (https://developers.google.com/closure/compiler/docs/compilation_levels).

Fixes #169