### PR TITLE
Clear all stored trend values when changing active trend.

### DIFF
--- a/libcosim/libcosim.go
+++ b/libcosim/libcosim.go
@@ -646,27 +646,27 @@ func initializeSimulation(sim *Simulation, status *structs.SimulationStatus, con
 }
 
 func resetSimulation(sim *Simulation, status *structs.SimulationStatus, configPath string, logDir string) (bool, string, string) {
-    var success = false
-    var message = ""
-    var configDir = ""
+	var success = false
+	var message = ""
+	var configDir = ""
 
-    success, message = executionStop(sim.Execution)
-    log.Println(message)
+	success, message = executionStop(sim.Execution)
+	log.Println(message)
 
-    if success{
-        status.Loaded = false
-        status.Status = "stopped"
-        status.ConfigDir = ""
-        status.Trends = []structs.Trend{}
-        status.Module = ""
-        success, message = simulationTeardown(sim)
-        log.Println(message)
-    }
+	if success {
+		status.Loaded = false
+		status.Status = "stopped"
+		status.ConfigDir = ""
+		status.Trends = []structs.Trend{}
+		status.Module = ""
+		success, message = simulationTeardown(sim)
+		log.Println(message)
+	}
 
-    success, message, configDir = initializeSimulation(sim, status, configPath, logDir)
-    log.Println(message)
+	success, message, configDir = initializeSimulation(sim, status, configPath, logDir)
+	log.Println(message)
 
-    return success, message, configDir
+	return success, message, configDir
 }
 
 func executeCommand(cmd []string, sim *Simulation, status *structs.SimulationStatus) (shorty structs.ShortLivedData, feedback structs.CommandFeedback) {
@@ -695,18 +695,18 @@ func executeCommand(cmd []string, sim *Simulation, status *structs.SimulationSta
 		success, message = simulationTeardown(sim)
 		shorty.ModuleData = sim.MetaData
 	case "reset":
-        status.Loading = true
-        var configDir string
-        success, message, configDir = resetSimulation(sim, status, cmd[1], cmd[2])
-        if success {
-            status.Loaded = true
-        	status.ConfigDir = configDir
-        	status.Status = "pause"
-        	shorty.ModuleData = sim.MetaData
-        	scenarios := findScenarios(status)
-        	shorty.Scenarios = &scenarios
-        }
-        status.Loading = false
+		status.Loading = true
+		var configDir string
+		success, message, configDir = resetSimulation(sim, status, cmd[1], cmd[2])
+		if success {
+			status.Loaded = true
+			status.ConfigDir = configDir
+			status.Status = "pause"
+			shorty.ModuleData = sim.MetaData
+			scenarios := findScenarios(status)
+			shorty.Scenarios = &scenarios
+		}
+		status.Loading = false
 	case "pause":
 		success, message = executionStop(sim.Execution)
 		status.Status = "pause"
@@ -728,7 +728,7 @@ func executeCommand(cmd []string, sim *Simulation, status *structs.SimulationSta
 	case "removetrend":
 		success, message = removeTrend(status, cmd[1])
 	case "active-trend":
-		success, message = activeTrend(status, cmd[1])
+		success, message = activeTrend(sim, status, cmd[1])
 	case "setlabel":
 		success, message = setTrendLabel(status, cmd[1], cmd[2])
 	case "trend-zoom":

--- a/libcosim/libcosim.go
+++ b/libcosim/libcosim.go
@@ -728,7 +728,7 @@ func executeCommand(cmd []string, sim *Simulation, status *structs.SimulationSta
 	case "removetrend":
 		success, message = removeTrend(status, cmd[1])
 	case "active-trend":
-		success, message = activeTrend(sim, status, cmd[1])
+		success, message = activeTrend(status, cmd[1])
 	case "setlabel":
 		success, message = setTrendLabel(status, cmd[1], cmd[2])
 	case "trend-zoom":
@@ -885,6 +885,7 @@ func GenerateJsonResponse(status *structs.SimulationStatus, sim *Simulation, fee
 		response.IsRealTimeSimulation = execStatus.isRealTimeSimulation
 		response.Module = findModuleData(status, sim.MetaData, sim.Observer)
 		response.ConfigDir = status.ConfigDir
+		generatePlotData(sim, status)
 		response.Trends = status.Trends
 		response.ManipulatedVariables = fetchManipulatedVariables(sim.Execution)
 		if sim.ScenarioManager != nil && isScenarioRunning(sim.ScenarioManager) {

--- a/libcosim/trending.go
+++ b/libcosim/trending.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"time"
 )
 
 func generateNextTrendId(status *structs.SimulationStatus) int {
@@ -118,20 +117,13 @@ func removeTrend(status *structs.SimulationStatus, trendIndex string) (bool, str
 	return true, "Removed trend"
 }
 
-func activeTrend(sim *Simulation, status *structs.SimulationStatus, trendIndex string) (bool, string) {
-	for _, trend := range status.Trends {
-		for i, _ := range trend.TrendSignals {
-			trend.TrendSignals[i].TrendXValues = nil
-			trend.TrendSignals[i].TrendYValues = nil
-		}
-	}
+func activeTrend(status *structs.SimulationStatus, trendIndex string) (bool, string) {
 	if len(trendIndex) > 0 {
 		idx, err := strconv.Atoi(trendIndex)
 		if err != nil {
 			return false, strCat("Could not parse trend index: ", trendIndex, " ", err.Error())
 		}
 		status.ActiveTrend = idx
-		generatePlotData(sim, status)
 	} else {
 		status.ActiveTrend = -1
 	}
@@ -141,6 +133,10 @@ func activeTrend(sim *Simulation, status *structs.SimulationStatus, trendIndex s
 func generatePlotData(sim *Simulation, status *structs.SimulationStatus) {
 	for _, trend := range status.Trends {
 		if status.ActiveTrend != trend.Id {
+			for i, _ := range trend.TrendSignals {
+				trend.TrendSignals[i].TrendXValues = nil
+				trend.TrendSignals[i].TrendYValues = nil
+			}
 			continue
 		}
 		switch trend.PlotType {
@@ -168,13 +164,6 @@ func generatePlotData(sim *Simulation, status *structs.SimulationStatus) {
 			}
 			break
 		}
-	}
-}
-
-func TrendLoop(sim *Simulation, status *structs.SimulationStatus) {
-	for {
-		generatePlotData(sim, status)
-		time.Sleep(1000 * time.Millisecond)
 	}
 }
 

--- a/libcosim/trending.go
+++ b/libcosim/trending.go
@@ -128,6 +128,12 @@ func activeTrend(status *structs.SimulationStatus, trendIndex string) (bool, str
 	} else {
 		status.ActiveTrend = -1
 	}
+	for _, trend := range status.Trends {
+		for i, _ := range trend.TrendSignals {
+			trend.TrendSignals[i].TrendXValues = nil
+			trend.TrendSignals[i].TrendYValues = nil
+		}
+	}
 	return true, "Changed active trend index"
 }
 

--- a/main.go
+++ b/main.go
@@ -28,7 +28,6 @@ func main() {
 	// Passing the channel to the go routine
 	go libcosim.StateUpdateLoop(state, &simulationStatus, &sim)
 	go libcosim.CommandLoop(state, &sim, cmd, &simulationStatus)
-	go libcosim.TrendLoop(&sim, &simulationStatus)
 
 	//Passing the channel to the server
 	server.Server(cmd, state, &simulationStatus, &sim)


### PR DESCRIPTION
Fixes #175 by removing all stored trend data when navigating to/from a plot.

If the user is looking at a lot of trend data (long time span, many variables etc), the whole application can slow down. By navigating away from the plot the application will become snappy again.

~~Consequence: When navigating to a plot, it can take 3-4 seconds before any data appears. Before the fix, old data was shown in the mean time.~~ Update; I have created a little shortcut such that when navigating to a plot, the initial data is generated much faster than before.