### PR TITLE
Recycle last take from state chan if ws write failed

### DIFF
--- a/server/websockets.go
+++ b/server/websockets.go
@@ -65,6 +65,7 @@ func stateLoop(state chan structs.JsonResponse, conn *websocket.Conn) {
 		if err != nil {
 			log.Println("write error:", err)
 			log.Println("latestState:", latestState)
+			state <- latestState
 			break
 		}
 	}


### PR DESCRIPTION
Fixes #143, no module metadata after browser refresh.

During a browser refresh event the websocket connection is closed, then created anew. On the server there is a loop which hangs on the `state` chan. During the refresh, the loop takes a value from the `state` chan, and exits when it fails to push the message on the now closed websocket connection. This means that on every refresh we lost the very first command response containing the model metadata.

The solution is pretty simple; if the websocket write fails, put `latestState` back on the `state` chan.