### PR TITLE
Make trend page refresh friendly

### DIFF
--- a/libcosim/trending.go
+++ b/libcosim/trending.go
@@ -131,8 +131,8 @@ func activeTrend(status *structs.SimulationStatus, trendIndex string) (bool, str
 }
 
 func generatePlotData(sim *Simulation, status *structs.SimulationStatus) {
-	for _, trend := range status.Trends {
-		if status.ActiveTrend != trend.Id {
+	for idx, trend := range status.Trends {
+		if status.ActiveTrend != idx {
 			for i, _ := range trend.TrendSignals {
 				trend.TrendSignals[i].TrendXValues = nil
 				trend.TrendSignals[i].TrendYValues = nil

--- a/src/client/controller.cljs
+++ b/src/client/controller.cljs
@@ -153,9 +153,8 @@
 
 (k/reg-event-fx ::trend-enter
                 (fn [{:keys [db]} [{:keys [index]}]]
-                  (let [trend-id (-> db :state :trends (get (int index)) :id)]
-                    (merge {:db (assoc db :active-trend-index index)}
-                           (socket-command ["active-trend" (str trend-id)])))))
+                  (merge {:db (assoc db :active-trend-index index)}
+                         (socket-command ["active-trend" (str index)]))))
 
 (k/reg-event-fx ::trend-leave
                 (fn [{:keys [db]} _]


### PR DESCRIPTION
Fixes #177.

The `active-trend` command now uses the trend index instead of the trend id as its argument. The trend index is part of the route data, so we don't depend on a data from the server before sending this command.

Test by loading a project, hit play, navigate to a trend and hit F5. When the page reloads, the plot should continue to be updated, and not be frozen like described in the issue.