### PR TITLE
Distribution includes c++ dependency licenses

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -30,3 +30,12 @@ lib, libboost_system.so.*       -> ./dist/lib
 lib, libboost_thread.so*        -> ./dist/lib
 lib, libcosim*.so               -> ./dist/lib
 lib, libzip.so*                 -> ./dist/lib
+
+., license*     -> ./dist/doc/licenses @ folder=True, ignore_case=True, keep_path=False
+., */license*   -> ./dist/doc/licenses @ folder=True, ignore_case=True, keep_path=False
+., copying*     -> ./dist/doc/licenses @ folder=True, ignore_case=True, keep_path=False
+., */copying*   -> ./dist/doc/licenses @ folder=True, ignore_case=True, keep_path=False
+., notice*      -> ./dist/doc/licenses @ folder=True, ignore_case=True, keep_path=False
+., */notice*    -> ./dist/doc/licenses @ folder=True, ignore_case=True, keep_path=False
+., authors*     -> ./dist/doc/licenses @ folder=True, ignore_case=True, keep_path=False
+., */authors*   -> ./dist/doc/licenses @ folder=True, ignore_case=True, keep_path=False


### PR DESCRIPTION
Distribution now includes a `doc/licenses/` with licenses for each dependency:

![image](https://user-images.githubusercontent.com/3470895/84018515-698d5700-a980-11ea-92ca-26db9a4b5d99.png)
