### PR TITLE
Update real time functionality

### DIFF
--- a/.github/workflows/ci-cosim-demo-app.yml
+++ b/.github/workflows/ci-cosim-demo-app.yml
@@ -39,8 +39,8 @@ jobs:
         os: [ubuntu-18.04, windows-2016]
 
     env:
-      CONAN_LOGIN_USERNAME_OSP: ${{ secrets.osp_conan_usr }}
-      CONAN_PASSWORD_OSP: ${{ secrets.osp_conan_pwd }}
+      CONAN_LOGIN_USERNAME_OSP: ${{ secrets.osp_artifactory_usr }}
+      CONAN_PASSWORD_OSP: ${{ secrets.osp_artifactory_pwd }}
       CONAN_REVISIONS_ENABLED: 1
       CONAN_NON_INTERACTIVE: True
 
@@ -57,7 +57,7 @@ jobs:
           conan profile update settings.compiler.libcxx=libstdc++11 default
         if: runner.os == 'Linux'
       - name: Add Conan remote
-        run: conan remote add osp https://osp-conan.azurewebsites.net/artifactory/api/conan/public --force
+        run: conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-public --force
       - name: Install Conan deps
         run: conan install -s build_type=Release .
       - name: Download client

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ your MinGW-w64 has been installed to e.g., C:\mingw\mingw64\bin).
 First, add the OSP Conan repository as a remote and configure the username and
 password to access it:
 
-    conan remote add osp https://osp-conan.azurewebsites.net/artifactory/api/conan/conan-local
+    conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-public
     conan user -p "Open Simulation Platform" -r osp osp
 
 ### Step 2: Build and run

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ First, add the OSP Conan repository as a remote and configure the username and
 password to access it:
 
     conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-public
-    conan user -p "Open Simulation Platform" -r osp osp
-
+    
 ### Step 2: Build and run
 
 You can do this in two ways:

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,7 +1,7 @@
 [generators]
 
 [requires]
-libcosimc/0.8.0@osp/testing-feature_update-real-time-api
+libcosimc/0.8.0@osp/testing
 
 [options]
 libcosim:fmuproxy=True

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,7 +1,7 @@
 [generators]
 
 [requires]
-libcosimc/0.7.0@osp/master
+libcosimc/0.8.0@osp/testing
 
 [options]
 libcosim:fmuproxy=True

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,7 +1,7 @@
 [generators]
 
 [requires]
-libcosimc/0.8.0@osp/testing
+libcosimc/0.8.0@osp/testing-feature_update-real-time-api
 
 [options]
 libcosim:fmuproxy=True

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -18,6 +18,9 @@ lib, boost_log*.dll             -> ./dist\bin
 lib, boost_system*.dll          -> ./dist\bin
 lib, boost_thread*.dll          -> ./dist\bin
 bin, cosim*.dll                 -> ./dist\bin
+bin, fmilib_shared.dll          -> ./dist\bin
+bin, xerces-c*.dll              -> ./dist\bin
+bin, yaml-cpp.dll               -> ./dist\bin
 bin, zip.dll                    -> ./dist\bin
 
 lib, libboost_chrono.so.*       -> ./dist/lib
@@ -29,6 +32,9 @@ lib, libboost_log.so.*          -> ./dist/lib
 lib, libboost_system.so.*       -> ./dist/lib
 lib, libboost_thread.so*        -> ./dist/lib
 lib, libcosim*.so               -> ./dist/lib
+lib, libfmilib_shared.so        -> ./dist/lib
+lib, libxerces-c*.so            -> ./dist/lib
+lib, libyaml-cpp.so.*           -> ./dist/lib
 lib, libzip.so*                 -> ./dist/lib
 
 ., license*     -> ./dist/doc/licenses @ folder=True, ignore_case=True, keep_path=False

--- a/src/client/controller.cljs
+++ b/src/client/controller.cljs
@@ -211,9 +211,12 @@
                   (socket-command ["enable-realtime"])))
 
 (k/reg-event-fx ::set-real-time-factor-target
-                (fn [{:keys [db]} [val]]
-                  (merge {:db (assoc db :enable-real-time-target true)}
-                         (socket-command ["set-custom-realtime-factor" val]))))
+                (fn [_ [val]]
+                  (socket-command ["set-custom-realtime-factor" val])))
+
+(k/reg-event-fx ::set-steps-to-monitor
+                (fn [_ [val]]
+                  (socket-command ["set-steps-to-monitor" val])))
 
 (k/reg-event-fx ::disable-realtime
                 (fn [_ _]

--- a/structs/structs.go
+++ b/structs/structs.go
@@ -23,26 +23,28 @@ type ManipulatedVariable struct {
 }
 
 type JsonResponse struct {
-	Loading              bool                  `json:"loading"`
-	Loaded               bool                  `json:"loaded"`
-	ExecutionState       string                `json:"executionState"`
-	LastErrorCode        string                `json:"lastErrorCode"`
-	LastErrorMessage     string                `json:"lastErrorMessage"`
-	SimulationTime       float64               `json:"time"`
-	RealTimeFactor       float64               `json:"realTimeFactor"`
-	RealTimeFactorTarget float64               `json:"realTimeFactorTarget"`
-	IsRealTimeSimulation bool                  `json:"isRealTime"`
-	ConfigDir            string                `json:"configDir,omitempty"`
-	LibVersion           Versions              `json:"libVersion,omitempty"`
-	Status               string                `json:"status,omitempty"`
-	Module               Module                `json:"module,omitempty"`
-	Trends               []Trend               `json:"trends"`
-	ModuleData           *MetaData             `json:"module-data,omitempty"`
-	Feedback             *CommandFeedback      `json:"feedback,omitempy"`
-	Scenarios            *[]string             `json:"scenarios,omitempty"`
-	Scenario             *interface{}          `json:"scenario,omitempty"`
-	RunningScenario      string                `json:"running-scenario"`
-	ManipulatedVariables []ManipulatedVariable `json:"manipulatedVariables"`
+	Loading                      bool                  `json:"loading"`
+	Loaded                       bool                  `json:"loaded"`
+	ExecutionState               string                `json:"executionState"`
+	LastErrorCode                string                `json:"lastErrorCode"`
+	LastErrorMessage             string                `json:"lastErrorMessage"`
+	SimulationTime               float64               `json:"time"`
+	TotalAverageRealTimeFactor   float64               `json:"totalAverageRealTimeFactor"`
+	RollingAverageRealTimeFactor float64               `json:"rollingAverageRealTimeFactor"`
+	RealTimeFactorTarget         float64               `json:"realTimeFactorTarget"`
+	IsRealTimeSimulation         bool                  `json:"isRealTime"`
+	StepsToMonitor               int                   `json:"stepsToMonitor"`
+	ConfigDir                    string                `json:"configDir,omitempty"`
+	LibVersion                   Versions              `json:"libVersion,omitempty"`
+	Status                       string                `json:"status,omitempty"`
+	Module                       Module                `json:"module,omitempty"`
+	Trends                       []Trend               `json:"trends"`
+	ModuleData                   *MetaData             `json:"module-data,omitempty"`
+	Feedback                     *CommandFeedback      `json:"feedback,omitempy"`
+	Scenarios                    *[]string             `json:"scenarios,omitempty"`
+	Scenario                     *interface{}          `json:"scenario,omitempty"`
+	RunningScenario              string                `json:"running-scenario"`
+	ManipulatedVariables         []ManipulatedVariable `json:"manipulatedVariables"`
 }
 
 type TrendSignal struct {


### PR DESCRIPTION
This PR implements updates to the real-time synchronization functionality pending merge of [libcosimc PR #18](https://github.com/open-simulation-platform/libcosimc/pull/18).

This updates the dependency version of libcosimc to the latest and greatest.

The real time factor is now split in two:
- Rolling average RTF (previously known as real time factor)
- Total average RTF

It is now also possible to change the number of samples the rolling average RTF calculation is based on.