### PR TITLE
boost dlls in bin folder

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -9,14 +9,14 @@ libcosim:fmuproxy=True
 [imports]
 include, cosim.h                -> ./include
 
-lib, boost_chrono*.dll          -> ./dist\bin
-lib, boost_context*.dll         -> ./dist\bin
-lib, boost_date_time*.dll       -> ./dist\bin
-lib, boost_fiber*.dll           -> ./dist\bin
-lib, boost_filesystem*.dll      -> ./dist\bin
-lib, boost_log*.dll             -> ./dist\bin
-lib, boost_system*.dll          -> ./dist\bin
-lib, boost_thread*.dll          -> ./dist\bin
+bin, boost_chrono*.dll          -> ./dist\bin
+bin, boost_context*.dll         -> ./dist\bin
+bin, boost_date_time*.dll       -> ./dist\bin
+bin, boost_fiber*.dll           -> ./dist\bin
+bin, boost_filesystem*.dll      -> ./dist\bin
+bin, boost_log*.dll             -> ./dist\bin
+bin, boost_system*.dll          -> ./dist\bin
+bin, boost_thread*.dll          -> ./dist\bin
 bin, cosim*.dll                 -> ./dist\bin
 bin, fmilib_shared.dll          -> ./dist\bin
 bin, xerces-c*.dll              -> ./dist\bin


### PR DESCRIPTION
boost dlls were missing in the windows artifact from the master branch. 
This fix can be verified by downloading and testing the cosim-demo-app artifact [here](https://github.com/open-simulation-platform/cosim-demo-app/actions/runs/1104727981)