### PR TITLE
Addressed failing builds

### DIFF
--- a/.github/workflows/ci-cosim-demo-app.yml
+++ b/.github/workflows/ci-cosim-demo-app.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install prerequisites
-        run: pip install conan
+        run: pip install conan==1.59
       - name: Configure libcxx for Linux
         run: |
           conan profile new default --detect
@@ -74,7 +74,6 @@ jobs:
       - name: packr build
         run: packr build -v
         env:
-          CGO_LDFLAGS: '-Wl,-rpath,$ORIGIN/../lib'
       - name: Prepare Windows distribution
         run: |
           cp ./cosim-demo-app.exe dist/bin

--- a/.github/workflows/ci-cosim-demo-app.yml
+++ b/.github/workflows/ci-cosim-demo-app.yml
@@ -74,6 +74,7 @@ jobs:
       - name: packr build
         run: packr build -v
         env:
+          CGO_LDFLAGS: '-Wl,-rpath,$ORIGIN/../lib'
       - name: Prepare Windows distribution
         run: |
           cp ./cosim-demo-app.exe dist/bin

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Server
 
 ### Required tools
   * Go dev tools: [Golang](https://golang.org/dl/) >= 1.11
-  * Compiler: [MinGW-w64](https://sourceforge.net/projects/mingw-w64/?source=typ_redirect) (Windows), GCC >= 7 (Linux)
+  * Compiler: [MinGW-w64](https://sourceforge.net/projects/mingw-w64/?source=typ_redirect) (Windows), GCC >= 9 (Linux)
   * Package managers: [Conan](https://conan.io/) and [Go Modules](https://github.com/golang/go/wiki/Modules)
 
 Throughout this guide, we will use Conan to manage C++ dependencies. However, you can also install the C++ dependencies manually.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Server
 ------------
 
 ### Required tools
+  * Conan v1.59 (currently v2 is not supported)
   * Go dev tools: [Golang](https://golang.org/dl/) >= 1.11
   * Compiler: [MinGW-w64](https://sourceforge.net/projects/mingw-w64/?source=typ_redirect) (Windows), GCC >= 9 (Linux)
   * Package managers: [Conan](https://conan.io/) and [Go Modules](https://github.com/golang/go/wiki/Modules)
@@ -24,6 +25,12 @@ Install a current version and specify win32 as thread when requested. Additional
 
 After installing it, you need to add it to the PATH environment variable (add the path where
 your MinGW-w64 has been installed to e.g., C:\mingw\mingw64\bin). 
+
+Alternatively, MinGW can also be installed via [chocolatey](https://chocolatey.org/install).
+Once chocolatey is installed, simply run the following command (as admin) to install MinGW:
+```ps
+choco install mingw
+```
 
 ### Step 1: Configure Conan
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ You can do this in two ways:
 #### Alternative 1: Using Conan
 
 From the cosim-demo-app source directory, get C/C++ dependencies using Conan:
-
-    conan install . -u -s build_type=Release -g virtualrunenv
-    go build
+```bash
+conan install . -u -s build_type=Release -g virtualrunenv
+source activate_run.sh # or run activate_run.bat in windows
+go build
+```
 
 To run the application on Windows:
 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,7 +1,7 @@
 [generators]
 
 [requires]
-libcosimc/0.11.0@osp/testing-scm_fix
+libcosimc/0.10.2@osp/stable
 
 [options]
 libcosim:proxyfmu=True

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,7 +1,7 @@
 [generators]
 
 [requires]
-libcosimc/0.10.1@osp/stable
+libcosimc/0.11.0@osp/testing-scm_fix
 
 [options]
 libcosim:proxyfmu=True

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -20,9 +20,10 @@ bin, boost_thread*.dll          -> ./dist/bin
 bin, cosim*.dll                 -> ./dist/bin
 bin, fmilib_shared.dll          -> ./dist/bin
 bin, xerces-c*.dll              -> ./dist/bin
-bin, yaml-cpp.dll               -> ./dist/bin
+bin, yaml-cpp*.dll              -> ./dist/bin
 bin, zip.dll                    -> ./dist/bin
 bin, proxyfmu*                  -> ./dist/bin
+bin, fmilibwrapper*.dll         -> ./dist/bin
 
 lib, libboost_chrono.so.*       -> ./dist/lib
 lib, libboost_context.so.*      -> ./dist/lib
@@ -35,8 +36,10 @@ lib, libboost_thread.so*        -> ./dist/lib
 lib, libcosim*.so               -> ./dist/lib
 lib, libfmilib_shared.so        -> ./dist/lib
 lib, libxerces-c*.so            -> ./dist/lib
-lib, libyaml-cpp.so.*           -> ./dist/lib
+lib, libyaml-cpp*.so.*          -> ./dist/lib
 lib, libzip.so*                 -> ./dist/lib
+lib, libfmilibwrapper*.so       -> ./dist/lib
+lib, libproxyfmu-client*.so     -> ./dist/lib
 
 ., license*     -> ./dist/doc/licenses @ folder=True, ignore_case=True, keep_path=False
 ., */license*   -> ./dist/doc/licenses @ folder=True, ignore_case=True, keep_path=False


### PR DESCRIPTION
- Addressed issues related to the failing builds
- Updated README.md for installing MinGW via chocolatey
- Using `libcosimc/0.10.2@osp/stable`